### PR TITLE
initial implementation of the finite state machine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+  - 1.6.2
+script: go test -v ./... -check.vv
+sudo: false
+notifications:
+  email:
+    on_success: never
+    on_failure: never

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Tim Heckman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,42 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package fsm
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+)
+
+func (*TestSuite) TestErrorCode_String(c *C) {
+	c.Check(ErrorUnknown.String(), Equals, "Unknown")
+	c.Check(ErrorMachineNotInitialized.String(), Equals, "MachineNotInitialized")
+	c.Check(ErrorTransitionNotPermitted.String(), Equals, "TransitionNotPermitted")
+	c.Check(ErrorStateUndefined.String(), Equals, "StateUndefined")
+	c.Check((ErrorUnknown + 100).String(), Equals, "Unknown")
+}
+
+func (t *TestSuite) TestError_Message(c *C) {
+	var str string
+
+	str = t.e.Message()
+	c.Check(str, Equals, "testMessage")
+}
+
+func (t *TestSuite) TestError_Code(c *C) {
+	var code ErrorCode
+
+	code = t.e.Code()
+	c.Check(code, Equals, ^ErrorCode(0))
+}
+
+func (t *TestSuite) TestError_Error(c *C) {
+	var errStr string
+
+	expected := fmt.Sprintf("Unknown (%d): testMessage", ^uint(0))
+
+	errStr = t.e.Error()
+	c.Check(errStr, Equals, expected)
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,71 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package fsm
+
+import "fmt"
+
+// ErrorCode is the type for package-specific error codes. This is used
+// within the Error struct, which allows you to programatically determine
+// the error cause.
+type ErrorCode uint
+
+func (e ErrorCode) String() string {
+	switch e {
+	case ErrorMachineNotInitialized:
+		return "MachineNotInitialized"
+	case ErrorTransitionNotPermitted:
+		return "TransitionNotPermitted"
+	case ErrorStateUndefined:
+		return "StateUndefined"
+	default:
+		return "Unknown"
+	}
+}
+
+const (
+	// ErrorUnknown is the default value
+	ErrorUnknown ErrorCode = iota
+
+	// ErrorMachineNotInitialized is an error returned when actions are taken on
+	// a machine before it has been initialized. A machine is initialized by
+	// adding at least one state and setting it as the initial state.
+	ErrorMachineNotInitialized
+
+	// ErrorTransitionNotPermitted is the error returned when trying to
+	// transition to an invalid state. In other words, the machine is not
+	// permitted to transition from the current state to the one requested.
+	ErrorTransitionNotPermitted
+
+	// ErrorStateUndefined is the error returned when the requested state is
+	// not defined within the machine.
+	ErrorStateUndefined
+)
+
+// Error is the struct representing internal errors.
+// This implements the error interface
+type Error struct {
+	message string
+	code    ErrorCode
+}
+
+// newErrorStruct uses messge and code to create an *Error struct. The *Error
+// struct implements the 'error' interface, so it should be able to be used
+// wherever 'error' is expected.
+func newErrorStruct(message string, code ErrorCode) *Error {
+	return &Error{
+		message: message,
+		code:    code,
+	}
+}
+
+// Message returns the error message.
+func (e *Error) Message() string { return e.message }
+
+// Code returns the error code.
+func (e *Error) Code() ErrorCode { return e.code }
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s (%d): %s", e.code, e.code, e.message)
+}

--- a/fsm.go
+++ b/fsm.go
@@ -1,0 +1,173 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+// Package fsm is a simple finite state machine in Go. This state machine is
+// safe for concurrent use, so multiple goroutines can work with the machine
+// safely.
+package fsm
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Version is the semantic version (SemVer) string.
+const Version = "0.0.1"
+
+// State is the machine state. It's really just a string.
+type State string
+
+// TransitionRuleSet is a set of allowed transitions. This uses map of struct{}
+// to implement a set.
+type TransitionRuleSet map[State]struct{}
+
+// Copy copies the TransitionRuleSet in to a different TransitionRuleSet.
+func (trs TransitionRuleSet) Copy() TransitionRuleSet {
+	srt := make(TransitionRuleSet)
+
+	for rule, value := range trs {
+		srt[rule] = value
+	}
+
+	return srt
+}
+
+// Machine is the state machine.
+type Machine struct {
+	transitions map[State]TransitionRuleSet
+	rules       map[State]map[State]State
+	mu          sync.RWMutex
+	state       State
+}
+
+// CurrentState returns the machine's current state. If the State returned is
+// "", then the machine has not been given an initial state.
+func (m *Machine) CurrentState() State {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.state
+}
+
+// StateTransitionRules returns the allowed states for
+func (m *Machine) StateTransitionRules(state State) (TransitionRuleSet, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.transitions == nil {
+		return nil, newErrorStruct("the machine has not been fully initialized", ErrorMachineNotInitialized)
+	}
+
+	// ensure the state has been registered
+	if _, ok := m.transitions[state]; !ok {
+		return nil, newErrorStruct(fmt.Sprintf("state %s has not been registered", state), ErrorStateUndefined)
+	}
+
+	return m.transitions[state].Copy(), nil
+}
+
+// AddStateTransitionRules is a function for adding valid state transitions to the machine.
+// This allows you to define which states any given state can be transitioned to.
+func (m *Machine) AddStateTransitionRules(sourceState State, destinationStates ...State) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// if the transitions map is nil, we need to allocate it
+	if m.transitions == nil {
+		m.transitions = make(map[State]TransitionRuleSet)
+	}
+
+	// if the map for the source state does not exist, allocate it
+	if m.transitions[sourceState] == nil {
+		m.transitions[sourceState] = make(TransitionRuleSet)
+	}
+
+	// get a reference to the map we care about
+	// avoids doing the map lookup for each iteration
+	mp := m.transitions[sourceState]
+
+	for _, dest := range destinationStates {
+		mp[dest] = struct{}{}
+	}
+
+	return nil
+}
+
+// StateTransition triggers a transition to the toState. This function is also
+// used to set the initial state of machine.
+//
+// Before you can transition to any state, even for the initial, you must define
+// it with AddStateTransition(). If you are setting the initial state, and that
+// state is not define, this will return an ErrInvalidInitialState error.
+//
+// When transitioning from a state, this function will return an error either
+// if the state transition is not allowed, or if the destination state has
+// not been defined. In both cases, it's seen as a non-permitted state transition.
+func (m *Machine) StateTransition(toState State) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// if this is nil we cannot assume any state
+	if m.transitions == nil {
+		return newErrorStruct("the machine has no states added", ErrorMachineNotInitialized)
+	}
+
+	// if the state is nothing, this is probably the initial state
+	if m.state == "" {
+		// if the state is not defined, it's invalid
+		if _, ok := m.transitions[toState]; !ok {
+			return newErrorStruct("the initial state has not been defined within the machine", ErrorStateUndefined)
+		}
+
+		// set the state
+		m.state = toState
+		return nil
+	}
+
+	// if we are not permitted to transition to this state...
+	if _, ok := m.transitions[m.state][toState]; !ok {
+		return newErrorStruct(fmt.Sprintf("transition from state %s to %s is not permitted", m.state, toState), ErrorTransitionNotPermitted)
+	}
+
+	// if the destination state was not defined...
+	if _, ok := m.transitions[toState]; !ok {
+		return newErrorStruct(fmt.Sprintf("state %s has not been registered", toState), ErrorStateUndefined)
+	}
+
+	m.state = toState
+	return nil
+}
+
+/*
+	NOT SURE I'LL EVER NEED THIS CODE, ALSO DON'T WANT TO STASH IT (IT'LL BE LOST)
+*/
+// func (m *Machine) RemoveStateTransition(sourceState State) error {
+// 	m.mu.Lock()
+// 	defer m.mu.Unlock()
+
+// 	if m.transitions == nil {
+// 		return nil
+// 	}
+
+// 	if m.state == sourceState {
+// 		return fmt.Errorf("the state %s cannot be removed as it is in use", sourceState)
+// 	}
+
+// 	delete(m.transitions, sourceState)
+
+// 	return nil
+// }
+
+// func (m *Machine) RemoveStateTransitionRule(sourceState State, destinationState State) error {
+// 	m.mu.Lock()
+// 	defer m.mu.Unlock()
+
+// 	if m.transitions == nil || m.transitions[sourceState] == nil {
+// 		return nil
+// 	}
+
+// 	delete(m.transitions[sourceState], destinationState)
+
+// 	return nil
+// }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1,0 +1,218 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package fsm
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct {
+	m *Machine
+	e *Error
+}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (t *TestSuite) setUpMachine(c *C) {
+	t.m = &Machine{}
+	c.Assert(t.m.AddStateTransitionRules("start", "started", "never_exist"), IsNil)
+	c.Assert(t.m.AddStateTransitionRules("started", "finishing", "aborted"), IsNil)
+	c.Assert(t.m.AddStateTransitionRules("aborted"), IsNil)
+	c.Assert(t.m.AddStateTransitionRules("finishing", "finished"), IsNil)
+	c.Assert(t.m.AddStateTransitionRules("finished"), IsNil)
+}
+
+func (t *TestSuite) setUpError(c *C) {
+	t.e = &Error{
+		message: "testMessage",
+		code:    ^ErrorCode(0),
+	}
+}
+
+func (t *TestSuite) SetUpSuite(c *C) {
+	t.setUpMachine(c)
+	t.setUpError(c)
+}
+
+func (t *TestSuite) TestMachine_AddStateTransitionRules(c *C) {
+	var ok bool
+	var err error
+	var trs TransitionRuleSet
+
+	// reset the machine
+	defer t.setUpMachine(c)
+
+	//
+	// Test adding a state that allow multiple transitions
+	//
+	err = t.m.AddStateTransitionRules("testing", "passing", "failing")
+	c.Assert(err, IsNil)
+
+	trs, err = t.m.StateTransitionRules("testing")
+	c.Assert(err, IsNil)
+	c.Assert(len(trs), Equals, 2)
+
+	_, ok = trs["passing"]
+	c.Check(ok, Equals, true)
+
+	_, ok = trs["failing"]
+	c.Check(ok, Equals, true)
+
+	//
+	// Test adding a state with no transitions works
+	//
+	err = t.m.AddStateTransitionRules("passing")
+	c.Assert(err, IsNil)
+
+	trs, err = t.m.StateTransitionRules("passing")
+	c.Assert(err, IsNil)
+	c.Check(len(trs), Equals, 0)
+}
+
+func (t *TestSuite) TestMachine_StateTransition(c *C) {
+	var ok bool
+	var err error
+	var state State
+	var fsmErr *Error
+
+	// reset the machine
+	defer t.setUpMachine(c)
+
+	//
+	// Test that when setting initial state, the requested state
+	// must have already been registered
+	//
+	err = t.m.StateTransition("does_not_exist_shouldn't_ever_exist")
+	c.Assert(err, NotNil)
+
+	fsmErr, ok = err.(*Error)
+	c.Assert(ok, Equals, true)
+	c.Check(fsmErr.Code(), Equals, ErrorStateUndefined)
+
+	//
+	// Test that setting the inital state to a valid state succeeds
+	//
+	err = t.m.StateTransition("start")
+	c.Assert(err, IsNil)
+
+	state = t.m.CurrentState()
+	c.Check(state, Equals, State("start"))
+
+	//
+	// Test that trying to transition to a state, that we are NOT
+	// permitted to transition to, fails to transition
+	//
+	err = t.m.StateTransition("finished")
+	c.Assert(err, NotNil)
+
+	fsmErr, ok = err.(*Error)
+	c.Assert(ok, Equals, true)
+	c.Check(fsmErr.Code(), Equals, ErrorTransitionNotPermitted)
+
+	//
+	// Test that trying to transition to a state, that is permitted yet
+	// hasn't been registered, fails to transition
+	//
+	err = t.m.StateTransition("never_exist")
+	c.Assert(err, NotNil)
+
+	fsmErr, ok = err.(*Error)
+	c.Assert(ok, Equals, true)
+	c.Check(fsmErr.Code(), Equals, ErrorStateUndefined)
+
+	//
+	// Test that transitioning to a valid state works
+	//
+	err = t.m.StateTransition("started")
+	c.Assert(err, IsNil)
+
+	state = t.m.CurrentState()
+	c.Check(state, Equals, State("started"))
+
+	//
+	// Test that an uninitialized machine errors
+	//
+	machine := &Machine{}
+
+	err = machine.StateTransition("starting")
+	c.Assert(err, NotNil)
+
+	fsmErr, ok = err.(*Error)
+	c.Assert(ok, Equals, true)
+	c.Check(fsmErr.Code(), Equals, ErrorMachineNotInitialized)
+}
+
+func (t *TestSuite) TestMachine_CurrentState(c *C) {
+	var state State
+
+	// reset the machine
+	defer t.setUpMachine(c)
+
+	state = t.m.CurrentState()
+	c.Check(state, Equals, State(""))
+
+	err := t.m.StateTransition("start")
+	c.Assert(err, IsNil)
+
+	state = t.m.CurrentState()
+	c.Check(state, Equals, State("start"))
+}
+
+func (t *TestSuite) TestMachine_StateTransitionRules(c *C) {
+	var ok bool
+	var err error
+	var trs TransitionRuleSet
+	var fsmErr *Error
+
+	//
+	// Test that retrieving a state with multiple valid destinations
+	// returns all states
+	//
+	trs, err = t.m.StateTransitionRules("started")
+	c.Assert(err, IsNil)
+	c.Assert(len(trs), Equals, 2)
+
+	_, ok = trs["finishing"]
+	c.Check(ok, Equals, true)
+
+	_, ok = trs["aborted"]
+	c.Check(ok, Equals, true)
+
+	//
+	// Test that retrieving a state with no valid destinations returns
+	// and empty TransitionRuleSet
+	//
+	trs, err = t.m.StateTransitionRules("aborted")
+	c.Assert(err, IsNil)
+	c.Check(len(trs), Equals, 0)
+
+	//
+	// Test that retreiving an unregistered state returns an error
+	//
+	trs, err = t.m.StateTransitionRules("never_exist")
+	c.Assert(err, NotNil)
+	c.Check(len(trs), Equals, 0)
+
+	fsmErr, ok = err.(*Error)
+	c.Assert(ok, Equals, true)
+	c.Check(fsmErr.Code(), Equals, ErrorStateUndefined)
+
+	//
+	// Test that an uninitialized machine errors
+	//
+	machine := &Machine{}
+
+	trs, err = machine.StateTransitionRules("")
+	c.Assert(err, NotNil)
+	c.Check(len(trs), Equals, 0)
+
+	fsmErr, ok = err.(*Error)
+	c.Assert(ok, Equals, true)
+	c.Check(fsmErr.Code(), Equals, ErrorMachineNotInitialized)
+}


### PR DESCRIPTION
This change introduces a simple implementation of a finite state machine. This initial implementation does not have support for events or callbacks.

This initial implementation simply tracks machine state, and whether a transition from state A to state B is permitted. Future improvements will add the ability to add callbacks and use events to change the state of the machine.
